### PR TITLE
Clean up redundant references, improve reliability of saving/loading

### DIFF
--- a/gambatte_watchOS/GameCore.h
+++ b/gambatte_watchOS/GameCore.h
@@ -57,6 +57,7 @@ static int const kScreenHeight = 144;
 @property (strong, nonatomic) NSURL *workingDirectory;
 @property (nonatomic, strong) void (^didRender)(uint32_t *);
 @property (nonatomic) uint32_t *activeInput;
+@property (nonatomic) BOOL paused;
 
 @property (nonatomic) BOOL enableFrameSkip;
 

--- a/gambatte_watchOS/GameLoader.swift
+++ b/gambatte_watchOS/GameLoader.swift
@@ -64,8 +64,13 @@ public class GameLoader: NSObject {
 		var reason: String
 	}
 	
-	let core: GameCore
-	let documentDirectory: URL
+	var core: GameCore? {
+		didSet {
+			if let oldCore = oldValue {
+				oldCore.stopEmulation()
+			}
+		}
+	}
 	let session = WCSession.default()
 	var activationState: WCSessionActivationState = .notActivated
 	
@@ -76,12 +81,6 @@ public class GameLoader: NSObject {
 	static let shared = GameLoader()
 	
 	private override init() {
-		
-		documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-		
-		core = GameCore()
-		core.workingDirectory = documentDirectory
-		
 		super.init()
 	}
 	
@@ -102,6 +101,13 @@ public class GameLoader: NSObject {
 		}
 	}
 	
+	func createCore() -> GameCore {
+		let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+		let core = GameCore()
+		core.workingDirectory = documentDirectory
+		return core
+	}
+	
 	func requestGames(_ success: @escaping (([Game]) -> Void), failure: @escaping ((Error) -> Void)) {
 		
 		let replyHandler: (([String: Any]) -> Void) = { (response) in
@@ -119,8 +125,12 @@ public class GameLoader: NSObject {
 	func loadGame(_ game: Game, _ success: @escaping ((GameCore) -> Void), failure: @escaping ((Error) -> Void)) {
 		
 		gameResponse = { [unowned self] (dataPath) in
-			self.core.loadFile(atPath: dataPath, success: { (core) in
+			
+			let core = self.createCore()
+			self.core = core
+			core.loadFile(atPath: dataPath, success: { (core) in
 				UserDefaults.standard.lastPlayed = game
+				core.startEmulation()
 				success(core)
 			}, failure: failure)
 		}

--- a/giovanni WatchKit Extension/GameplayController.swift
+++ b/giovanni WatchKit Extension/GameplayController.swift
@@ -170,6 +170,7 @@ class GameplayController: WKInterfaceController {
 		crownSequencer.focus()
 
 		if let core = loader.core {
+			core.load(fromSlot: 0)
 //			core.paused = false
 		}
 	}
@@ -181,6 +182,7 @@ class GameplayController: WKInterfaceController {
 		crownSequencer.resignFocus()
 		
 		if let core = loader.core {
+			core.save(toSlot: 0)
 //			core.paused = true;
 		}
 	}

--- a/giovanni WatchKit Extension/GameplayController.swift
+++ b/giovanni WatchKit Extension/GameplayController.swift
@@ -84,7 +84,7 @@ class GameplayController: WKInterfaceController {
 	@IBAction func BSelected()		{ pressInputOnce(.B) }
 	
 	@IBAction func resetSelected() {
-		core?.resetEmulation()
+		loader.core?.resetEmulation()
 	}
 	
 	@IBOutlet var ALabel: WKInterfaceLabel!
@@ -94,7 +94,7 @@ class GameplayController: WKInterfaceController {
 	
 	func updateDirectionalInputs() {
 
-		guard let core = core else {
+		guard let core = loader.core else {
 			DPadLabel.setText(GameInput(rawValue: 0).displaySymbol)
 			return
 		}
@@ -126,18 +126,6 @@ class GameplayController: WKInterfaceController {
 	}
 	
 	let loader = GameLoader.shared
-	var core: GameCore? {
-		didSet {
-			if let core = core {
-				core.didRender = { [weak self] buffer in
-					guard let s = self else {
-						return
-					}
-					s.updateSnapshotIfNeeded(with: buffer)
-				}
-			}
-		}
-	}
 	
 	var tick = 0
 	let refreshRate = 20;
@@ -151,8 +139,14 @@ class GameplayController: WKInterfaceController {
 		}
 		
 		let success: ((GameCore) -> Void) = { [unowned self] (core) in
-			self.core = core
+			core.didRender = { [weak self] buffer in
+				guard let s = self else {
+					return
+				}
+				s.updateSnapshotIfNeeded(with: buffer)
+			}
 		}
+		
 		let failureHandler: ((Error) -> Void) = { [unowned self] (error) in
 			print("error loading game \(error)")
 			self.presentAlert(withTitle: "There was an issue loading this game", message: nil, preferredStyle: .alert, actions: [
@@ -169,40 +163,38 @@ class GameplayController: WKInterfaceController {
 		}
 	}
 	
-	override func didAppear() {
-		super.didAppear()
-		
-		if let core = core {
-			core.startEmulation()
-			core.load(fromSlot: 0)
-		}
+	override func willActivate() {
+		super.willActivate()
 		
 		crownSequencer.delegate = self
 		crownSequencer.focus()
+
+		if let core = loader.core {
+//			core.paused = false
+		}
 	}
 	
 	override func didDeactivate() {
 		super.didDeactivate()
 		
-		if let core = core {
-			core.save(toSlot: 0)
-			core.stopEmulation()
-		}
-		
 		crownSequencer.delegate = nil
 		crownSequencer.resignFocus()
+		
+		if let core = loader.core {
+//			core.paused = true;
+		}
 	}
-	
+
 	var lastSnapshot: UIImage?
 	
 	func updateSnapshotIfNeeded(with buffer: UnsafeMutablePointer<UInt32>) {
 		
 		tick += 1
-		if tick > refreshRate || core == nil {
+		if tick > refreshRate || loader.core == nil {
 			return
 		}
 		
-		let snapshot = core!.createSnapshot(from: buffer)
+		let snapshot = loader.core!.createSnapshot(from: buffer)
 		
 		// compare before updating. Not sure if faster.
 //		if let lhs = lastSnapshot, let rhs = snapshot, lhs.equalPixels(to: rhs) {
@@ -230,7 +222,7 @@ class GameplayController: WKInterfaceController {
 	
 	func setInputSelected(_ input: GameInput, selected: Bool) {
 		
-		if let core = core {
+		if let core = loader.core {
 			core.update(input, selected: selected)
 		}
 		

--- a/giovanni WatchKit Extension/LibraryController.swift
+++ b/giovanni WatchKit Extension/LibraryController.swift
@@ -60,11 +60,6 @@ class LibraryController: WKInterfaceController {
 //		if let game = UserDefaults.standard.lastPlayed {
 //			presentGame(game)
 //		}
-		
-		let loader = GameLoader.shared
-		if loader.core != nil {
-			loader.core = nil
-		}
 	}
 	
 	func reloadGames() {

--- a/giovanni WatchKit Extension/LibraryController.swift
+++ b/giovanni WatchKit Extension/LibraryController.swift
@@ -60,6 +60,11 @@ class LibraryController: WKInterfaceController {
 //		if let game = UserDefaults.standard.lastPlayed {
 //			presentGame(game)
 //		}
+		
+		let loader = GameLoader.shared
+		if loader.core != nil {
+			loader.core = nil
+		}
 	}
 	
 	func reloadGames() {


### PR DESCRIPTION
# What this does
More or less restores changes made in 259102d32df8a4f4bb48228a061ec1910710fb97. These changes were reverted last minute (1d2d82b06dde35129e04bf483ca33042e643ee02) due to an unexpected crash, resulting from `GameLoader` attempting to load save states before beginning the emulator.

These changes don't fix all crashes, but appear to reduce a number of issues, eliminating issues that can be reproduced in the simulator.