### PR TITLE
Accept ROM Document Type

### DIFF
--- a/gambatte_watchOS/Game.swift
+++ b/gambatte_watchOS/Game.swift
@@ -39,8 +39,8 @@ public struct Game {
 	public let path: String
 	
 	public init?(dictionary: [String: Any]) {
-		guard let name = dictionary["name"] as? String,
-		 let path = dictionary["path"] as? String
+		guard let name = dictionary["name"] as? String, !name.isEmpty,
+		 let path = dictionary["path"] as? String, !path.isEmpty
 			else {
 				return nil
 		}

--- a/gambatte_watchOS/GameLoader.swift
+++ b/gambatte_watchOS/GameLoader.swift
@@ -71,7 +71,9 @@ public class GameLoader: NSObject {
 	
 	var activationCompletion: ((Error?) -> Void)?
 	
-	var gameResponse: ((String) -> Void)?
+	fileprivate var gameResponse: ((String) -> Void)?
+	
+	var gamesUpdated: (([Game]) -> Void)?
 	
 	static let shared = GameLoader()
 	
@@ -104,13 +106,12 @@ public class GameLoader: NSObject {
 	
 	func requestGames(_ success: @escaping (([Game]) -> Void), failure: @escaping ((Error) -> Void)) {
 		
-		let replyHandler: (([String: Any]) -> Void) = { (response) in
-			guard let gamesRaw = response["games"] as? [[String: Any]] else {
+		let replyHandler: (([String: Any]) -> Void) = { [unowned self] (response) in
+			if let games = self.createGames(from: response) {
+				success(games)
+			} else {
 				failure(GameLoaderError(reason: "bad response"))
-				return
 			}
-			let games = gamesRaw.flatMap { Game(dictionary: $0) }
-			success(games)
 		}
 
 		session.sendMessage(["requestGames": 1], replyHandler: replyHandler, errorHandler: failure)
@@ -145,9 +146,22 @@ public class GameLoader: NSObject {
 	var cacheURL: URL? {
 		return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
 	}
+	
+	func createGames(from response: [String: Any]) -> [Game]? {
+		guard let gamesRaw = response["games"] as? [[String: Any]] else {
+			return nil
+		}
+		return gamesRaw.flatMap { Game(dictionary: $0) }
+	}
 }
 
 extension GameLoader: WCSessionDelegate {
+	
+	public func session(_ session: WCSession, didReceiveMessage message: [String : Any], replyHandler: @escaping ([String : Any]) -> Void) {
+		if let games = createGames(from: message), let handler = gamesUpdated {
+			handler(games)
+		}
+	}
 	
 	public func session(_ session: WCSession, didReceive file: WCSessionFile) {
 		print("received \(file)")

--- a/gambatte_watchOS/GameLoader.swift
+++ b/gambatte_watchOS/GameLoader.swift
@@ -137,7 +137,11 @@ public class GameLoader: NSObject {
 	func cachedURL(for game: Game) -> URL? {
 		do {
 			let contents = try FileManager.default.contentsOfDirectory(at: cacheURL!, includingPropertiesForKeys: nil, options: [.skipsSubdirectoryDescendants, .skipsHiddenFiles])
-			return contents.first(where: { $0.lastPathComponent.contains(game.name) })
+			return contents.first(where: { url -> Bool in
+				let matchingName = url.lastPathComponent.contains(game.name)
+				let matchingExtension = (url.pathExtension == URL(string: game.path)!.pathExtension)// .isValidROMExtension
+				return matchingName && matchingExtension
+			})
 		} catch {
 			return nil
 		}
@@ -157,7 +161,7 @@ public class GameLoader: NSObject {
 
 extension GameLoader: WCSessionDelegate {
 	
-	public func session(_ session: WCSession, didReceiveMessage message: [String : Any], replyHandler: @escaping ([String : Any]) -> Void) {
+	public func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
 		if let games = createGames(from: message), let handler = gamesUpdated {
 			handler(games)
 		}

--- a/giovanni WatchKit Extension/GameplayController.swift
+++ b/giovanni WatchKit Extension/GameplayController.swift
@@ -210,7 +210,9 @@ class GameplayController: WKInterfaceController {
 //		}
 //		lastSnapshot = snapshot
 		
-		self.image.setImage(snapshot)
+		DispatchQueue.main.async {
+			self.image.setImage(snapshot)
+		}
 		tick = 0
 	}
 	

--- a/giovanni WatchKit Extension/LibraryController.swift
+++ b/giovanni WatchKit Extension/LibraryController.swift
@@ -63,7 +63,10 @@ class LibraryController: WKInterfaceController {
 			self.games = games
 		}
 		
-		print("WATCH ROM URL:, \(GameLoader.shared.cacheURL!.absoluteString)")
+		guard let cacheURL = GameLoader.shared.cacheURL else {
+			return
+		}
+		print("WATCH ROM URL: , \(cacheURL.absoluteString)")
 		// Auto-loads the last played game
 //		if let game = UserDefaults.standard.lastPlayed {
 //			presentGame(game)

--- a/giovanni WatchKit Extension/LibraryController.swift
+++ b/giovanni WatchKit Extension/LibraryController.swift
@@ -42,6 +42,7 @@ class LibraryController: WKInterfaceController {
 	var games: [Game]? {
 		didSet {
 			if let games = games {
+				noGamesFound = games.count == 0
 				populateTable(with: games)
 			}
 		}
@@ -51,16 +52,28 @@ class LibraryController: WKInterfaceController {
 	
 	override func awake(withContext context: Any?) {
 		super.awake(withContext: context)
+		
 		reloadGames()
 	}
+	
 	override func willActivate() {
 		super.willActivate()
 
+		GameLoader.shared.gamesUpdated = { [unowned self] games in
+			self.games = games
+		}
+		
 		print("WATCH ROM URL:, \(GameLoader.shared.cacheURL!.absoluteString)")
 		// Auto-loads the last played game
 //		if let game = UserDefaults.standard.lastPlayed {
 //			presentGame(game)
 //		}
+	}
+	
+	override func didDeactivate() {
+		super.didDeactivate()
+		
+		GameLoader.shared.gamesUpdated = nil
 	}
 	
 	func reloadGames() {
@@ -69,7 +82,6 @@ class LibraryController: WKInterfaceController {
 		populateTable(with: [])
 		
 		let success: (([Game]) -> Void) = { [unowned self] games in
-			self.noGamesFound = games.count == 0
 			self.games = games
 		}
 		

--- a/giovanni WatchKit Extension/LibraryController.swift
+++ b/giovanni WatchKit Extension/LibraryController.swift
@@ -56,6 +56,7 @@ class LibraryController: WKInterfaceController {
 	override func willActivate() {
 		super.willActivate()
 
+		print("WATCH ROM URL:, \(GameLoader.shared.cacheURL!.absoluteString)")
 		// Auto-loads the last played game
 //		if let game = UserDefaults.standard.lastPlayed {
 //			presentGame(game)

--- a/giovanni.xcodeproj/project.pbxproj
+++ b/giovanni.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		B2DF6DA01E614C69001A811B /* GameRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DF6D9F1E614C69001A811B /* GameRow.swift */; };
 		B2DF6DA21E619D16001A811B /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B2DC85111E5DC6CC00CC1028 /* Interface.storyboard */; };
 		B2FC9BDE1E608AD5004D19C0 /* GameplayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FC9BDD1E608AD5004D19C0 /* GameplayController.swift */; };
+		B2FCD4571E813EE900718BCF /* FileManagerAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FCD4561E813EE900718BCF /* FileManagerAdditions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -409,6 +410,7 @@
 		B2DF6DD21E61C3D3001A811B /* Game.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Game.swift; path = ../gambatte_watchOS/Game.swift; sourceTree = "<group>"; };
 		B2DF6DD31E61C3D3001A811B /* GameLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GameLoader.swift; path = ../gambatte_watchOS/GameLoader.swift; sourceTree = "<group>"; };
 		B2FC9BDD1E608AD5004D19C0 /* GameplayController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameplayController.swift; sourceTree = "<group>"; };
+		B2FCD4561E813EE900718BCF /* FileManagerAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileManagerAdditions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -726,6 +728,7 @@
 			children = (
 				B2DC84FD1E5DC6CB00CC1028 /* AppDelegate.swift */,
 				B2DC84FF1E5DC6CB00CC1028 /* ViewController.swift */,
+				B2FCD4561E813EE900718BCF /* FileManagerAdditions.swift */,
 				B2DC85011E5DC6CB00CC1028 /* Main.storyboard */,
 				B2DC85041E5DC6CB00CC1028 /* Assets.xcassets */,
 				B2DC85061E5DC6CB00CC1028 /* LaunchScreen.storyboard */,
@@ -1086,6 +1089,7 @@
 			files = (
 				B2DC85001E5DC6CB00CC1028 /* ViewController.swift in Sources */,
 				B2DC84FE1E5DC6CB00CC1028 /* AppDelegate.swift in Sources */,
+				B2FCD4571E813EE900718BCF /* FileManagerAdditions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/giovanni.xcodeproj/project.pbxproj
+++ b/giovanni.xcodeproj/project.pbxproj
@@ -955,17 +955,14 @@
 					};
 					B2DC84F91E5DC6CB00CC1028 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = USYSB33394;
 						ProvisioningStyle = Automatic;
 					};
 					B2DC850B1E5DC6CC00CC1028 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = USYSB33394;
 						ProvisioningStyle = Automatic;
 					};
 					B2DC851A1E5DC6CC00CC1028 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = USYSB33394;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1316,7 +1313,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
-				DEVELOPMENT_TEAM = USYSB33394;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "giovanni WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
@@ -1338,7 +1335,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
-				DEVELOPMENT_TEAM = USYSB33394;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "giovanni WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
@@ -1362,7 +1359,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = USYSB33394;
+				DEVELOPMENT_TEAM = "";
 				IBSC_MODULE = giovanni_WatchKit_Extension;
 				INFOPLIST_FILE = giovanni_watchOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1382,7 +1379,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = USYSB33394;
+				DEVELOPMENT_TEAM = "";
 				IBSC_MODULE = giovanni_WatchKit_Extension;
 				INFOPLIST_FILE = giovanni_watchOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1400,7 +1397,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = USYSB33394;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = giovanni_iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gabrieloc.giovanni;
@@ -1414,7 +1411,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = USYSB33394;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = giovanni_iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gabrieloc.giovanni;

--- a/giovanni.xcodeproj/project.pbxproj
+++ b/giovanni.xcodeproj/project.pbxproj
@@ -955,14 +955,17 @@
 					};
 					B2DC84F91E5DC6CB00CC1028 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = USYSB33394;
 						ProvisioningStyle = Automatic;
 					};
 					B2DC850B1E5DC6CC00CC1028 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = USYSB33394;
 						ProvisioningStyle = Automatic;
 					};
 					B2DC851A1E5DC6CC00CC1028 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = USYSB33394;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1313,7 +1316,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = USYSB33394;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "giovanni WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
@@ -1335,7 +1338,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = USYSB33394;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "giovanni WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
@@ -1359,7 +1362,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = USYSB33394;
 				IBSC_MODULE = giovanni_WatchKit_Extension;
 				INFOPLIST_FILE = giovanni_watchOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1379,7 +1382,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = USYSB33394;
 				IBSC_MODULE = giovanni_WatchKit_Extension;
 				INFOPLIST_FILE = giovanni_watchOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1397,7 +1400,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = USYSB33394;
 				INFOPLIST_FILE = giovanni_iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gabrieloc.giovanni;
@@ -1411,7 +1414,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = USYSB33394;
 				INFOPLIST_FILE = giovanni_iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gabrieloc.giovanni;

--- a/giovanni_iOS/AppDelegate.swift
+++ b/giovanni_iOS/AppDelegate.swift
@@ -44,6 +44,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		return true
 	}
 
+	func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+		
+		let rootController = UIApplication.shared.keyWindow?.rootViewController
+		
+		return FileManager.default.receiveFile(at: url, completion: { (name) -> Bool in
+			let alert = UIAlertController(title: "Received \(name)",
+				message: "Hit refresh on your watch.",
+				preferredStyle: .alert)
+			alert.addAction(UIAlertAction(title: "Close", style: .default, handler: nil))
+			rootController?.present(alert, animated: true, completion: nil)
+			return true
+		}) { (error) -> Bool in
+			let alert = UIAlertController(title: "Error Receiving File",
+			                              message: error.localizedDescription,
+			                              preferredStyle: .alert)
+			alert.addAction(UIAlertAction(title: "Close", style: .default, handler: nil))
+			rootController?.present(alert, animated: true, completion: nil)
+			return false
+		}
+	}
+	
 	func applicationWillResignActive(_ application: UIApplication) {
 		// Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
 		// Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.

--- a/giovanni_iOS/AppDelegate.swift
+++ b/giovanni_iOS/AppDelegate.swift
@@ -46,21 +46,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 	func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
 		
-		let rootController = UIApplication.shared.keyWindow?.rootViewController
+		guard let rootController = UIApplication.shared.keyWindow?.rootViewController as? ViewController else {
+			return false
+		}
 		
 		return FileManager.default.receiveFile(at: url, completion: { (name) -> Bool in
 			let alert = UIAlertController(title: "Received \(name)",
-				message: "Hit refresh on your watch.",
+				message: "",
 				preferredStyle: .alert)
 			alert.addAction(UIAlertAction(title: "Close", style: .default, handler: nil))
-			rootController?.present(alert, animated: true, completion: nil)
+			rootController.present(alert, animated: true, completion: nil)
+			rootController.sendGamesList()
 			return true
 		}) { (error) -> Bool in
 			let alert = UIAlertController(title: "Error Receiving File",
 			                              message: error.localizedDescription,
 			                              preferredStyle: .alert)
 			alert.addAction(UIAlertAction(title: "Close", style: .default, handler: nil))
-			rootController?.present(alert, animated: true, completion: nil)
+			rootController.present(alert, animated: true, completion: nil)
 			return false
 		}
 	}

--- a/giovanni_iOS/FileManagerAdditions.swift
+++ b/giovanni_iOS/FileManagerAdditions.swift
@@ -1,0 +1,29 @@
+//
+//  FileManagerAdditions.swift
+//  giovanni
+//
+//  Created by Gabriel O'Flaherty-Chan on 2017-03-21.
+//  Copyright © 2017 Gabrieloc. All rights reserved.
+//
+
+import Foundation
+
+extension FileManager {
+	
+	var documentsDirectory: URL? {
+		let directory: FileManager.SearchPathDirectory = .documentDirectory
+		return FileManager.default.urls(for: directory, in: .userDomainMask).first as URL?
+	}
+	
+	func receiveFile(at fileURL: URL, completion: ((String) -> Bool), failure: ((Error) -> Bool)) -> Bool {
+		
+		do {
+			let name = fileURL.lastPathComponent
+			let destinationPath = documentsDirectory!.appendingPathComponent(name)
+			try FileManager.default.moveItem(at: fileURL, to: destinationPath)
+			return completion(name)
+		} catch (let error) {
+			return failure(error)
+		}
+	}
+}

--- a/giovanni_iOS/FileManagerAdditions.swift
+++ b/giovanni_iOS/FileManagerAdditions.swift
@@ -16,6 +16,18 @@ extension String {
 
 extension FileManager {
 	
+	enum FileError: LocalizedError {
+		case invalidExtension
+		
+		public var errorDescription: String? {
+			switch self {
+			case .invalidExtension:
+				return "Not a valid ROM file"
+			}
+			return nil
+		}
+	}
+	
 	var documentsDirectory: URL? {
 		let directory: FileManager.SearchPathDirectory = .documentDirectory
 		return FileManager.default.urls(for: directory, in: .userDomainMask).first as URL?
@@ -24,7 +36,7 @@ extension FileManager {
 	func receiveFile(at fileURL: URL, completion: ((String) -> Bool), failure: ((Error) -> Bool)) -> Bool {
 		
 		guard fileURL.pathExtension.isValidROMExtension else {
-			return false
+			return failure(FileError.invalidExtension)
 		}
 		
 		do {

--- a/giovanni_iOS/FileManagerAdditions.swift
+++ b/giovanni_iOS/FileManagerAdditions.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+extension String {
+	var isValidROMExtension: Bool {
+		return ["gb", "gbc", "zip"].contains(self)
+	}
+}
+
 extension FileManager {
 	
 	var documentsDirectory: URL? {
@@ -16,6 +22,10 @@ extension FileManager {
 	}
 	
 	func receiveFile(at fileURL: URL, completion: ((String) -> Bool), failure: ((Error) -> Bool)) -> Bool {
+		
+		guard fileURL.pathExtension.isValidROMExtension else {
+			return false
+		}
 		
 		do {
 			let name = fileURL.lastPathComponent

--- a/giovanni_iOS/FileManagerAdditions.swift
+++ b/giovanni_iOS/FileManagerAdditions.swift
@@ -1,9 +1,34 @@
 //
 //  FileManagerAdditions.swift
-//  giovanni
+//  GIOVANNI
 //
-//  Created by Gabriel O'Flaherty-Chan on 2017-03-21.
-//  Copyright © 2017 Gabrieloc. All rights reserved.
+//  Copyright (c) <2017>, Gabriel O'Flaherty-Chan
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  1. Redistributions of source code must retain the above copyright
+//  notice, this list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//  3. All advertising materials mentioning features or use of this software
+//  must display the following acknowledgement:
+//  This product includes software developed by skysent.
+//  4. Neither the name of the skysent nor the
+//  names of its contributors may be used to endorse or promote products
+//  derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY skysent ''AS IS'' AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL skysent BE LIABLE FOR ANY
+//  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 import Foundation

--- a/giovanni_iOS/FileManagerAdditions.swift
+++ b/giovanni_iOS/FileManagerAdditions.swift
@@ -49,7 +49,6 @@ extension FileManager {
 			case .invalidExtension:
 				return "Not a valid ROM file"
 			}
-			return nil
 		}
 	}
 	

--- a/giovanni_iOS/Info.plist
+++ b/giovanni_iOS/Info.plist
@@ -6,6 +6,20 @@
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
 	<string>GIOVANNI</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeIconFiles</key>
+			<array/>
+			<key>CFBundleTypeName</key>
+			<string>ROM</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/giovanni_iOS/ViewController.swift
+++ b/giovanni_iOS/ViewController.swift
@@ -140,4 +140,10 @@ extension ViewController: WCSessionDelegate {
 		}
 	}
 	
+	func sendGamesList() {
+		guard let games = loadGames() else {
+			return
+		}
+		WCSession.default().sendMessage(["games": games], replyHandler: nil, errorHandler: nil)
+	}
 }

--- a/giovanni_iOS/ViewController.swift
+++ b/giovanni_iOS/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController {
 	
 		prepareSession()
 		
-		if let documentsDirectory = documentsDirectory {
+		if let documentsDirectory = FileManager.default.documentsDirectory {
 			print("ROM URL: \(documentsDirectory)")
 		}
 	}
@@ -58,19 +58,16 @@ class ViewController: UIViewController {
 		return .lightContent
 	}
 	
-	var documentsDirectory: URL? {
-		let directory: FileManager.SearchPathDirectory = .documentDirectory
-		return FileManager.default.urls(for: directory, in: .userDomainMask).first as URL?
-	}
+
 
 	func loadGames() -> [[String: String]]? {
 
-		guard let documentsDirectory = documentsDirectory else {
+		guard let documentsDirectory = FileManager.default.documentsDirectory else {
 			return nil
 		}
 		
 		do {
-			let URLs = try FileManager.default.contentsOfDirectory(at: documentsDirectory, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+			let URLs = try FileManager.default.contentsOfDirectory(at: documentsDirectory, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants])
 			return encodeFiles(with: URLs)
 		} catch {
 			return nil

--- a/giovanni_iOS/ViewController.swift
+++ b/giovanni_iOS/ViewController.swift
@@ -75,11 +75,12 @@ class ViewController: UIViewController {
 	}
 	
 	func encodeFiles(with URLs: [URL]) -> [[String: String]] {
-		return URLs.reduce([[String: String]]()) {
+		return URLs.filter { $0.pathExtension.isValidROMExtension }.reduce([[String: String]]()) {
 			
 			var games = $0.0
-			
+
 			let path = $0.1
+
 			let name = path
 				.lastPathComponent
 				.components(separatedBy: ".")
@@ -144,6 +145,11 @@ extension ViewController: WCSessionDelegate {
 		guard let games = loadGames() else {
 			return
 		}
+		
+		if WCSession.default().activationState != .activated {
+			prepareSession()
+		}
+		
 		WCSession.default().sendMessage(["games": games], replyHandler: nil, errorHandler: nil)
 	}
 }


### PR DESCRIPTION
# What This Does
Allows `gb` and `gbc` files to be opened in Giovanni, removing the need to sync with iTunes. For development, this change also allows roms to be dragged into the simulator, making it much easier to test things.

Here's an example of drag and drop:
![mar-23-2017 00-49-02](https://cloud.githubusercontent.com/assets/983669/24206858/d8de2686-0f62-11e7-8ab7-a2a0bae37601.gif)

Here's an example of opening a rom from Safari:
![mar-23-2017 01-04-41](https://cloud.githubusercontent.com/assets/983669/24207642/c3e40b2c-0f64-11e7-9e10-7466f5c32fd3.gif)
