### PR TITLE
Fix accidental "swipe back" gesture from game

### DIFF
--- a/giovanni WatchKit Extension/GameplayController.swift
+++ b/giovanni WatchKit Extension/GameplayController.swift
@@ -145,6 +145,8 @@ class GameplayController: WKInterfaceController {
 	override func awake(withContext context: Any?) {
 		super.awake(withContext: context)
 
+		setTitle("ｘ")
+
 		guard let game = context as? Game else {
 			pop()
 			return

--- a/giovanni WatchKit Extension/LibraryController.swift
+++ b/giovanni WatchKit Extension/LibraryController.swift
@@ -146,13 +146,8 @@ class LibraryController: WKInterfaceController {
 			row.titleLabel.setText(game.name)
 		}
 	}
-	
-	func presentGame(_ game: Game) {
-		pushController(withName: "GamePlay", context: game)
-	}
-	
-	override func table(_ table: WKInterfaceTable, didSelectRowAt rowIndex: Int) {
-		let game = games![rowIndex - 1]
-		presentGame(game)
+
+	override func contextForSegue(withIdentifier segueIdentifier: String, in table: WKInterfaceTable, rowIndex: Int) -> Any? {
+		return games![rowIndex - 1]
 	}
 }

--- a/giovanni_watchOS/Base.lproj/Interface.storyboard
+++ b/giovanni_watchOS/Base.lproj/Interface.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="7hZ-R3-GZe">
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="7hZ-R3-GZe">
     <device id="watch42" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="12029"/>
     </dependencies>
     <scenes>
@@ -91,7 +91,7 @@ SL</string>
                     </connections>
                 </controller>
             </objects>
-            <point key="canvasLocation" x="286" y="276"/>
+            <point key="canvasLocation" x="326" y="268"/>
         </scene>
         <!--Library Controller-->
         <scene sceneID="hYo-3W-FtS">
@@ -139,6 +139,7 @@ SL</string>
                                     </group>
                                     <connections>
                                         <outlet property="titleLabel" destination="NDJ-HY-IOo" id="C04-0a-hT1"/>
+                                        <segue destination="AgC-eL-Hgc" kind="modal" id="Jr0-Lf-gGe"/>
                                     </connections>
                                 </tableRow>
                             </items>


### PR DESCRIPTION
# What This Does
When panning in a game, it's easy to accidentally trigger the swipe back gesture to return to the games list. This prevents that, replacing the push transition with a modal transition. The tradeoff is present controllers modally hides the clock, and there doesn't appear to be any way to prevent this, or disable the gesture.